### PR TITLE
Import lazy_static explicitly

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Rust/Rust.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Rust/Rust.stg
@@ -84,6 +84,8 @@ use std::ops::{DerefMut, Deref};
 use std::borrow::{Borrow,BorrowMut};
 use std::any::Any;
 
+use lazy_static::lazy_static;
+
 <parser>
 <if(file.genPackage)>
 }
@@ -98,6 +100,8 @@ use antlr_rust::tree::ParseTreeListener;
 use super::<file.grammarName; format="low">parser::*;
 
 use std::any::Any;
+
+use lazy_static::lazy_static;
 
 pub trait <file.grammarName>Listener : ParseTreeListener{
 
@@ -1087,6 +1091,8 @@ use std::sync::Arc;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::ops::{Deref, DerefMut};
+
+use lazy_static::lazy_static;
 
 <lexer>
 <if(lexerFile.genPackage)>


### PR DESCRIPTION
Since Rust 2018, `#[macro_use] sxtern crate ...` is not necessary for using macros.
This enables building parsers without importing `lazy_static` in the root of crate.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->